### PR TITLE
Fix deprecation warning for Rails 6

### DIFF
--- a/lib/mjml/rails/template_handler.rb
+++ b/lib/mjml/rails/template_handler.rb
@@ -9,8 +9,8 @@ module MJML
         @base_handler = base_handler
       end
 
-      def call(template)
-        compiled = get_handler(@base_handler).call(template)
+      def call(template, source=nil)
+        compiled = get_handler(@base_handler).call(template, source)
         "::MJML::Parser.new.call!(begin;#{compiled};end).html_safe"
       end
 


### PR DESCRIPTION
This is to fix deprecation warning after upgraded to Rails 6

```
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> #<MJML::Rails::TemplateHandler:0x00007fad1c00bf60>.call(template)
To:
  >> #<MJML::Rails::TemplateHandler:0x00007fad1c00bf60>.call(template, source)
```