### PR TITLE
Update minify and validation_level to be MJML4 compliant

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -65,11 +65,19 @@ module MJML
     end
 
     def minify_output
-      '--min' if MJML::Config.minify_output
+      if MJML::Feature::version[:major] >= 4
+      '--config.minify true' if MJML::Config.minify_output
+      else
+        '--min' if MJML::Config.minify_output
+      end
     end
 
     def validation_level
-      "--level=#{MJML::Config.validation_level}" if MJML::Feature.available?(:validation_level)
+      if MJML::Feature::version[:major] >= 4
+        "--config.validationLevel #{MJML::Config.validation_level}"
+      else
+        "--level=#{MJML::Config.validation_level}" if MJML::Feature.available?(:validation_level)
+      end
     end
 
     def output_from_file


### PR DESCRIPTION
MJML 4 completely reworked the command line arguments. Amongst others, minify and validation_level cannot be use the same way anymore. There are probably others that would need a change, though.