### PR TITLE
Rails 7.1 compatibility

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -45,7 +45,7 @@ module MJML
     end
 
     def partial?
-      (@template =~ ROOT_TAGS_REGEX).nil?
+      (@template.to_s =~ ROOT_TAGS_REGEX).nil?
     end
 
     def mjml_bin


### PR DESCRIPTION
ActionView::OutputBuffer is no longer a String subclass, as of https://github.com/rails/rails/pull/45614. We need to convert it to a string with `#to_s` before calling `=~`.